### PR TITLE
Fix field value save issue with multiple values

### DIFF
--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -29,7 +29,6 @@ class Plugin {
 		add_action( 'gform_editor_js', [ __CLASS__, 'editor_js' ] );
 		add_action( 'gform_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ], 10, 2 );
 		add_action( 'gform_after_submission', [ __CLASS__, 'after_submission' ], 1, 2 );
-		add_filter( 'gform_save_field_value', [ __CLASS__, 'save_field_value' ], 10, 5 );
 		add_action( 'gform_update_post/setup_form', [ __CLASS__, 'capture_post_id' ] );
 		add_action( 'gform_loaded', function() {
 			require __DIR__ . '/TermSelectField.php';
@@ -215,25 +214,6 @@ class Plugin {
 				wp_set_object_terms( $entry['post_id'], $term_ids, $field->termSelectTax, false );
 			}
 		}
-	}
-
-	/**
-	 * Intercept fields as they are being saved.
-	 *
-	 * @filter gform_save_field_value
-	 */
-	static function save_field_value( $value, $entry, $field, $form, $input_id ) {
-		// @todo: will post_id be set yet if this is a new post?
-		if ( !self::field_is_this( $field ) ) {
-			return $value;
-		}
-		$term_ids = (array) $value;
-		// the front end should have forced this max, but let's be sure
-		if ( !empty( $field->termSelectMax ) ) {
-			$term_ids = array_slice( $term_ids, 0, $field->termSelectMax );
-		}
-		// save as comma delimited values (so it is db field friendly)
-		return implode( ',', $term_ids );
 	}
 
 	/**

--- a/inc/TermSelectField.php
+++ b/inc/TermSelectField.php
@@ -45,4 +45,11 @@ class TermSelectField extends \GF_Field {
 		}
 	}
 
+	/**
+	 * We expect the value to be an array.
+	 */
+	function is_value_submission_array() {
+		return true;
+	}
+
 }


### PR DESCRIPTION
Updates in GForms added new logic to account for field types that expect an array of values or just a flat value; the default is no array. This caused term fields that accepted multiple values to result in an empty value, thus clearing out term values.

Also, the new logic automatically does the value imploding that we were doing in the `save_field_value` method, so that is no longer necessary.